### PR TITLE
Fix setup.py for building on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ __author__ = 'Sujit Mandal'
 from setuptools import setup 
 
 def readme():
-    with open('README.md') as files:
+    with open('README.md', 'r', encoding='utf-8') as files:
         README = files.read()
 
-    return(README)
+    return README
 
 setup(
     name = 'python-gmail',


### PR DESCRIPTION
This addresses the issue noticed when this package was being built for conda-forge. It would have also broken for individuals attempting to pip install this from source.